### PR TITLE
fix: pass plugin name to StarTools.get_data_dir() to avoid inspect.stack() crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -542,7 +542,7 @@ class QQToolsPlugin(Star):
         if self.tool_config.get("wake_scheduler", True):
             # 初始化唤醒调度器
             # 使用官方 API 获取插件专属数据目录
-            data_dir = str(StarTools.get_data_dir())
+            data_dir = str(StarTools.get_data_dir("astrbot_plugin_qq_tools"))
             
             self.wake_scheduler = WakeScheduler(self.context, data_dir)
             self.wake_scheduler.set_wake_callback(self._wake_callback)


### PR DESCRIPTION
### Problem
When `StarTools.get_data_dir()` is called without arguments, the framework attempts to deduce the calling plugin name using `inspect.stack()`. Under certain environments (such as dynamic reloading, testing shims, or direct scripts where `__main__` is the entrypoint), metadata extraction fails, throwing a fatal `RuntimeError: 无法获取模块 __main__ 的元信息`.

### Solution
Explicitly pass the plugin name `"astrbot_plugin_qq_tools"` to the call of `StarTools.get_data_dir()` in `main.py` to avoid this dynamic inspection crash. This is safe, backwards-compatible, and robust across all execution environments.

### Validation
- Verified and tested successfully under AstrBot official environment.

---

### 💡 Ecosystem & Framework Context
This issue stems from a known vulnerability in the AstrBot core framework's path-resolving API. We have submitted a root-cause fix to the official AstrBot core repository: **[AstrBot Core PR #8588](https://github.com/AstrBotDevs/AstrBot/pull/8588)**.

However, this plugin-level change (passing the plugin name explicitly) remains **highly necessary** to ensure backward compatibility. It prevents the plugin from crashing on older installations of AstrBot that have not upgraded to the latest core version.

This is a safe, non-breaking, and recommended change.