### PR TITLE
[codex] Reduce image context bloat and preserve media references

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -128,7 +128,7 @@
         "type": "bool",
         "description": "自动注入图片到 LLM 视觉上下文",
         "hint": "启用后，get_message_detail 工具默认会将消息中的图片注入到 LLM 视觉上下文中，让模型能「看到」图片。LLM 调用时可通过 inject_images 参数覆盖此设置。",
-        "default": false,
+        "default": true,
         "condition": {
           "message_detail": true
         }
@@ -703,7 +703,7 @@
           "api_history_count": {
             "description": "每次获取历史消息的条数",
             "type": "int",
-            "default": 10,
+            "default": 50,
             "condition": {
               "cache_bot_messages": true
             }
@@ -711,7 +711,7 @@
           "cache_size": {
             "description": "每个会话的缓存上限（条）",
             "type": "int",
-            "default": 50,
+            "default": 300,
             "condition": {
               "cache_bot_messages": true
             }
@@ -720,7 +720,7 @@
             "description": "会话缓存过期时间（秒）",
             "hint": "超过此时间没有新消息的会话缓存将被自动清理，释放内存。设置为 0 表示禁用自动清理。",
             "type": "int",
-            "default": 3600,
+            "default": 86400,
             "condition": {
               "cache_bot_messages": true
             }

--- a/main.py
+++ b/main.py
@@ -1184,6 +1184,12 @@ class QQToolsPlugin(Star):
             # 即使 delay_append_msg_id 或 skip_msg_id_for_commands 启用（不注入到 event），
             # 工具仍能从缓存获取 MSG_ID
             cache_content = event.message_str
+            media_summary = self._extract_event_media_summary(event)
+            if media_summary:
+                if not cache_content.strip():
+                    cache_content = media_summary
+                elif media_summary not in cache_content:
+                    cache_content = f"{cache_content} {media_summary}"
             if show_msg_id and effective_delay:
                 # delay 模式：event 中没有 MSG_ID，但缓存中要有
                 if id_suffix not in cache_content:
@@ -1229,6 +1235,83 @@ class QQToolsPlugin(Star):
             return False
         
         return any(stripped.startswith(p) for p in command_prefixes)
+
+    def _extract_event_media_summary(self, event: AstrMessageEvent) -> str:
+        """Build compact, searchable media markers for the message cache."""
+        raw_message = getattr(event.message_obj, 'raw_message', None)
+        raw_segments = []
+        if raw_message and hasattr(raw_message, 'message') and isinstance(raw_message.message, list):
+            raw_segments = raw_message.message
+        elif isinstance(raw_message, dict) and isinstance(raw_message.get('message'), list):
+            raw_segments = raw_message.get('message', [])
+
+        markers = self._extract_media_markers_from_segments(raw_segments)
+        if not markers:
+            messages = event.get_messages() if hasattr(event, 'get_messages') else []
+            if not messages and hasattr(event.message_obj, 'message'):
+                messages = event.message_obj.message
+            markers = self._extract_media_markers_from_components(messages)
+
+        return " ".join(dict.fromkeys(markers))
+
+    def _extract_media_markers_from_components(self, messages: list) -> List[str]:
+        markers: List[str] = []
+        for comp in messages or []:
+            if isinstance(comp, Comp.Image):
+                markers.append("[Image]")
+            elif hasattr(Comp, "Video") and isinstance(comp, Comp.Video):
+                markers.append("[Video]")
+            elif hasattr(Comp, "Record") and isinstance(comp, Comp.Record):
+                markers.append("[Audio]")
+            elif hasattr(Comp, "File") and isinstance(comp, Comp.File):
+                name = getattr(comp, 'name', '') or getattr(comp, 'file', '') or 'file'
+                markers.append(f"[File:{self._short_media_value(name, 48) or 'file'}]")
+            elif isinstance(comp, Comp.Reply):
+                markers.append(f"[Reply:{getattr(comp, 'id', '')}]")
+                if getattr(comp, 'chain', None):
+                    for marker in self._extract_media_markers_from_components(comp.chain):
+                        markers.append(f"[Quoted{marker.strip('[]')}]")
+        return markers
+
+    def _extract_media_markers_from_segments(self, segments: list) -> List[str]:
+        markers: List[str] = []
+        for seg in segments or []:
+            if not isinstance(seg, dict):
+                continue
+            seg_type = seg.get('type', '')
+            data = seg.get('data', {}) if isinstance(seg.get('data', {}), dict) else {}
+            if seg_type == 'image':
+                ident = self._short_media_value(data.get('file_id') or data.get('file_unique') or data.get('file'), 32)
+                size = self._short_media_value(data.get('file_size'), 24)
+                extra = []
+                if ident:
+                    extra.append(f"id={ident}")
+                if size:
+                    extra.append(f"size={size}")
+                markers.append(f"[Image {' '.join(extra)}]" if extra else "[Image]")
+            elif seg_type == 'video':
+                markers.append("[Video]")
+            elif seg_type == 'record':
+                markers.append("[Audio]")
+            elif seg_type == 'file':
+                name = self._short_media_value(data.get('name') or data.get('file'), 48) or 'file'
+                markers.append(f"[File:{name}]")
+            elif seg_type == 'reply':
+                markers.append(f"[Reply:{data.get('id', '')}]")
+        return markers
+
+    def _short_media_value(self, value: object, max_len: int) -> str:
+        if value is None:
+            return ""
+        text = str(value).strip()
+        if not text:
+            return ""
+        lowered = text[:64].lower()
+        if lowered.startswith(("data:", "base64", "http://", "https://")):
+            return ""
+        if len(text) > 256 and re.fullmatch(r"[A-Za-z0-9+/=]+", text):
+            return ""
+        return re.sub(r"\s+", "_", text)[:max_len]
 
     def _get_real_message_timestamp(self, event: AstrMessageEvent) -> int:
         """获取消息的真实时间戳
@@ -2114,20 +2197,28 @@ class QQToolsPlugin(Star):
             if seg_type == 'text':
                 parts.append(data.get('text', ''))
             elif seg_type == 'image':
-                parts.append('[图片]')
+                ident = self._short_media_value(data.get('file_id') or data.get('file_unique') or data.get('file'), 32)
+                size = self._short_media_value(data.get('file_size'), 24)
+                extra = []
+                if ident:
+                    extra.append(f"id={ident}")
+                if size:
+                    extra.append(f"size={size}")
+                parts.append(f"[Image {' '.join(extra)}]" if extra else "[Image]")
             elif seg_type == 'at':
                 qq = data.get('qq', '')
                 parts.append(f'@{qq}')
             elif seg_type == 'face':
-                parts.append('[表情]')
+                parts.append('[Face]')
             elif seg_type == 'record':
-                parts.append('[语音]')
+                parts.append('[Audio]')
             elif seg_type == 'video':
-                parts.append('[视频]')
+                parts.append('[Video]')
             elif seg_type == 'file':
-                parts.append(f"[文件:{data.get('name', 'file')}]")
+                name = self._short_media_value(data.get('name') or data.get('file'), 48) or 'file'
+                parts.append(f"[File:{name}]")
             elif seg_type == 'reply':
-                parts.append(f"[回复:{data.get('id', '')}]")
+                parts.append(f"[Reply:{data.get('id', '')}]")
             else:
                 parts.append(f'[{seg_type}]')
         

--- a/tools/get_message_detail.py
+++ b/tools/get_message_detail.py
@@ -1,19 +1,16 @@
-import os
 import json
 import base64
 import asyncio
 import aiohttp
-import uuid
 from io import BytesIO
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional, Dict, List, Any, Tuple
+from typing import Optional, Dict, Any, Tuple
 from astrbot.api import logger
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import AiocqhttpMessageEvent
 from astrbot.core.agent.tool import FunctionTool, ToolExecResult
 from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.astr_agent_context import AstrAgentContext
 from astrbot.core.agent.message import ImageURLPart
-from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 from ..utils import call_onebot
 
 # Gemini 支持的图片格式
@@ -372,9 +369,8 @@ class GetMessageDetailTool(FunctionTool):
             
             # 检查是否需要转换
             if content_type in SUPPORTED_IMAGE_FORMATS:
-                # 格式已支持，直接编码为 base64（轻量操作，无需线程池）
-                base64_data = base64.b64encode(image_data).decode('utf-8')
-                return f"data:{content_type};base64,{base64_data}", None
+                # 模型已支持的格式直接保留原始 URL，避免把图片转成巨大的 data URL 注入上下文。
+                return url, None
             
             elif content_type in CONVERT_IMAGE_FORMATS or content_type.startswith('image/'):
                 # 需要转换格式 - 使用线程池避免阻塞事件循环


### PR DESCRIPTION
## Summary
- keep supported image formats as URLs instead of converting them to base64 data URLs in `get_message_detail`
- add compact media markers to the message cache so image-only messages remain searchable later
- normalize history media placeholders to ASCII markers such as `[Image]`, `[Audio]`, and `[Video]`
- enable image detail injection by default and expand the short-term message cache defaults

## Why
When image payloads are converted to inline base64 or later replaced by plain placeholders, the model can end up with either too much context or no image at all. In the latter case, image description requests may hallucinate because only a placeholder reaches the provider.

## Impact
Follow-up questions can locate the exact message containing media and fetch that message detail, instead of reinjecting broad image history. This keeps context smaller while preserving a path to retrieve the referenced image.

## Validation
- `python -m py_compile Z:\ASTR??\qq-tools-repo\main.py`
- `python -m json.tool Z:\ASTR??\qq-tools-repo\_conf_schema.json`
